### PR TITLE
docs: remove redundant note

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -28,9 +28,6 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 > StreamKit is early-stage (`v0.1.0`). Breaking changes are expected and the security model is still evolving.
 > If you expose a StreamKit instance to other machines, read the [Security](/guides/security/) guide first.
 
-> [!NOTE]
-> Official Docker images are published for `linux/amd64` (x86_64). On ARM hosts, use “Build from Source” or run with amd64 emulation.
-
 ## A quick look
 
 <div className="sk-landing-video" aria-label="StreamKit demo video">


### PR DESCRIPTION
#### Summary

Removing a redundant node from landing page.