### PR TITLE
fix(monitor): throttle stats, show slow mixer edges, and improve `moq_peer` counters

### DIFF
--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -160,7 +160,11 @@ pub enum NodeState {
     /// - Partial functionality (some features unavailable)
     ///
     /// The node continues processing but users should be aware of reduced quality.
-    Degraded { reason: String },
+    Degraded {
+        reason: String,
+        #[ts(type = "JsonValue")]
+        details: Option<serde_json::Value>,
+    },
 
     /// Node has encountered a fatal error and stopped processing.
     /// Manual intervention is required to restart the node.
@@ -306,7 +310,8 @@ pub mod state_helpers {
         state_tx: &mpsc::Sender<NodeStateUpdate>,
         node_name: &str,
         reason: impl Into<String>,
+        details: Option<serde_json::Value>,
     ) {
-        emit_state(state_tx, node_name, NodeState::Degraded { reason: reason.into() });
+        emit_state(state_tx, node_name, NodeState::Degraded { reason: reason.into(), details });
     }
 }

--- a/crates/nodes/Cargo.toml
+++ b/crates/nodes/Cargo.toml
@@ -97,7 +97,7 @@ default = [
 # Individual features for each node.
 passthrough = ["dep:schemars"]
 audio_gain = ["dep:schemars"]
-audio_mixer = ["dep:schemars"]
+audio_mixer = ["dep:schemars", "dep:serde_json"]
 audio_resampler = ["dep:schemars", "dep:rubato"]
 audio_pacer = ["dep:schemars"]
 file_io = ["dep:schemars"]

--- a/ui/src/components/TypedEdge.tsx
+++ b/ui/src/components/TypedEdge.tsx
@@ -2,14 +2,23 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-import { BaseEdge, getBezierPath, type EdgeProps } from '@xyflow/react';
+import { BaseEdge, EdgeLabelRenderer, getBezierPath, type EdgeProps } from '@xyflow/react';
 import React from 'react';
 
+import { SKTooltip } from '@/components/Tooltip';
 import type { PacketType } from '@/types/types';
 import { getPacketTypeColor } from '@/utils/packetTypes';
 
 export type TypedEdgeData = {
   resolvedType?: PacketType;
+  alert?: {
+    kind: string;
+    severity: 'warning' | 'error';
+    tooltip?: {
+      title: string;
+      lines: string[];
+    };
+  };
   [key: string]: unknown;
 };
 
@@ -23,7 +32,7 @@ const TypedEdge: React.FC<EdgeProps> = ({
   style = {},
   data,
 }) => {
-  const [edgePath] = getBezierPath({
+  const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
     sourceY,
     sourcePosition,
@@ -33,17 +42,80 @@ const TypedEdge: React.FC<EdgeProps> = ({
   });
 
   const resolvedType = (data as TypedEdgeData | undefined)?.resolvedType;
+  const alert = (data as TypedEdgeData | undefined)?.alert;
 
   // Get color based on resolved type
   const typeColor = resolvedType ? getPacketTypeColor(resolvedType) : 'var(--sk-primary)';
 
+  const alertColor =
+    alert?.severity === 'error'
+      ? 'var(--sk-danger)'
+      : alert?.severity === 'warning'
+        ? 'var(--sk-warning)'
+        : null;
+
   // Override style with type-specific color
   const edgeStyle: React.CSSProperties = {
     ...(style || {}),
-    stroke: typeColor,
+    stroke: alertColor ?? typeColor,
+    strokeDasharray: alertColor
+      ? '6, 4'
+      : (style as React.CSSProperties | undefined)?.strokeDasharray,
+    strokeWidth: alertColor ? 3 : (style as React.CSSProperties | undefined)?.strokeWidth,
   };
 
-  return <BaseEdge path={edgePath} style={edgeStyle} />;
+  const badgeIcon =
+    alert?.severity === 'error'
+      ? '❌'
+      : alert?.severity === 'warning' && alert?.kind === 'slow_input_timeout'
+        ? '⏱️'
+        : alert
+          ? '⚠️'
+          : null;
+
+  const tooltipContent =
+    alert?.tooltip && badgeIcon ? (
+      <div style={{ fontSize: 12 }}>
+        <div style={{ fontWeight: 600, marginBottom: 4 }}>
+          {badgeIcon} {alert.tooltip.title}
+        </div>
+        {alert.tooltip.lines.map((line) => (
+          <div key={line} className="code-font" style={{ fontSize: 11, lineHeight: '1.4' }}>
+            {line}
+          </div>
+        ))}
+      </div>
+    ) : null;
+
+  return (
+    <>
+      <BaseEdge path={edgePath} style={edgeStyle} />
+      {alertColor && badgeIcon && (
+        <EdgeLabelRenderer>
+          <SKTooltip content={tooltipContent} side="top">
+            <div
+              className="nodrag nopan"
+              style={{
+                position: 'absolute',
+                transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+                background: alertColor,
+                color: 'white',
+                border: '1px solid var(--sk-border-strong)',
+                borderRadius: 999,
+                padding: '2px 6px',
+                fontSize: 12,
+                fontWeight: 700,
+                pointerEvents: 'auto',
+                boxShadow: '0 2px 10px var(--sk-shadow)',
+              }}
+            >
+              {badgeIcon}
+            </div>
+          </SKTooltip>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
 };
 
 export default TypedEdge;

--- a/ui/src/stores/sessionStore.edge-cases.test.ts
+++ b/ui/src/stores/sessionStore.edge-cases.test.ts
@@ -74,7 +74,7 @@ describe('sessionStore edge cases', () => {
       const states: NodeState[] = [
         'Initializing',
         'Running',
-        { Degraded: { reason: 'test degradation' } },
+        { Degraded: { reason: 'test degradation', details: null } },
         'Running',
       ];
 

--- a/ui/src/types/generated/api-types.ts
+++ b/ui/src/types/generated/api-types.ts
@@ -83,7 +83,7 @@ bidirectional: boolean, };
 
 export type StopReason = "completed" | "input_closed" | "output_closed" | "shutdown" | "no_inputs" | "unknown";
 
-export type NodeState = "Initializing" | "Ready" | "Running" | { "Recovering": { reason: string, details: JsonValue, } } | { "Degraded": { reason: string, } } | { "Failed": { reason: string, } } | { "Stopped": { reason: StopReason, } };
+export type NodeState = "Initializing" | "Ready" | "Running" | { "Recovering": { reason: string, details: JsonValue, } } | { "Degraded": { reason: string, details: JsonValue, } } | { "Failed": { reason: string, } } | { "Stopped": { reason: StopReason, } };
 
 export type NodeStats = { 
 /**
@@ -345,7 +345,7 @@ is_fragment: boolean, };
 
 export type AudioAsset = { 
 /**
- * Unique identifier (filename without extension)
+ * Unique identifier (filename, including extension)
  */
 id: string, 
 /**
@@ -353,7 +353,7 @@ id: string,
  */
 name: string, 
 /**
- * Absolute path on the server
+ * Server-relative path suitable for `core::file_reader` (e.g., `samples/audio/system/foo.wav`)
  */
 path: string, 
 /**


### PR DESCRIPTION
#### Summary

- Fixes node stats spam by correcting `NodeStatsTracker` throttling (consistent across source/sink nodes; first snapshot emitted promptly).
- Adds structured degraded details for mixer slow-input timeouts (`slow_pins`, `newly_slow_pins`, `sync_timeout_ms`) and surfaces them in Monitor:
  - Node tooltip shows upstream `from_node.from_pin` → `to_pin` mapping.
  - A visible edge badge (⏱️) marks degraded connections; hover shows the same slow-input context.
- Fixes `moq_peer` stats so ingress from publisher clients increments input counters; forwarding to subscribers is counted as well.
- Regenerates TS API types to include Degraded.details; tests/lint remain green.
