### PR TITLE
fix: stabilize load tests and monitoring

### DIFF
--- a/apps/skit-cli/src/main.rs
+++ b/apps/skit-cli/src/main.rs
@@ -84,6 +84,11 @@ enum Commands {
         /// Override server URL from config
         #[arg(long)]
         server: Option<String>,
+        /// Override dynamic.session_count from config
+        ///
+        /// Useful for quickly scaling down presets like `stress-dynamic` on laptops.
+        #[arg(long)]
+        sessions: Option<usize>,
         /// Override test duration (seconds)
         #[arg(short, long)]
         duration: Option<u64>,
@@ -382,7 +387,7 @@ async fn main() {
                 std::process::exit(1);
             }
         },
-        Commands::LoadTest { config_path, config, server, duration, cleanup } => {
+        Commands::LoadTest { config_path, config, server, sessions, duration, cleanup } => {
             info!("Starting StreamKit load test");
 
             let config = match (config_path, config) {
@@ -397,7 +402,7 @@ async fn main() {
             };
 
             if let Err(e) =
-                streamkit_client::run_load_test(&config, server, duration, cleanup).await
+                streamkit_client::run_load_test(&config, server, sessions, duration, cleanup).await
             {
                 // Error already logged via tracing above
                 error!(error = %e, "Load test failed");

--- a/apps/skit-cli/src/shell.rs
+++ b/apps/skit-cli/src/shell.rs
@@ -636,7 +636,7 @@ impl Shell {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if args.is_empty() {
             eprintln!(
-                "Usage: loadtest <config.toml> [--server <url>] [--duration <seconds>] [--cleanup]"
+                "Usage: loadtest <config.toml> [--server <url>] [--sessions <n>] [--duration <seconds>] [--cleanup]"
             );
             eprintln!("Example: loadtest samples/loadtest/stress-moq-peer.toml --duration 30");
             return Ok(());
@@ -654,6 +654,7 @@ impl Shell {
         }
 
         let mut server_override = None;
+        let mut sessions_override = None;
         let mut duration_override = None;
         let mut cleanup = false;
 
@@ -684,6 +685,20 @@ impl Shell {
                         return Ok(());
                     }
                 },
+                "--sessions" => {
+                    if i + 1 < args.len() {
+                        if let Ok(sessions) = args[i + 1].parse::<usize>() {
+                            sessions_override = Some(sessions);
+                            i += 2;
+                        } else {
+                            eprintln!("--sessions requires a numeric value");
+                            return Ok(());
+                        }
+                    } else {
+                        eprintln!("--sessions requires a value");
+                        return Ok(());
+                    }
+                },
                 "--cleanup" => {
                     cleanup = true;
                     i += 1;
@@ -701,6 +716,7 @@ impl Shell {
         match crate::load_test::run_load_test(
             config_path,
             server_override,
+            sessions_override,
             duration_override,
             cleanup,
         )

--- a/docs/src/content/docs/guides/load-testing.md
+++ b/docs/src/content/docs/guides/load-testing.md
@@ -30,6 +30,7 @@ Examples:
 
 - `just lt stress-oneshot`
 - `just lt oneshot-opus-transcode-fast`
+- `just lt stress-dynamic sessions=10` (or `just lt stress-dynamic --sessions 10`)
 - `just lt dynamic-tune-heavy --cleanup`
 
 ### Oneshot (HTTP batch pipelines)

--- a/justfile
+++ b/justfile
@@ -104,6 +104,8 @@ skit-lt config='loadtest.toml' *args='':
 # Examples:
 # - `just lt`                           # runs `samples/loadtest/stress-oneshot.toml` by default
 # - `just lt stress-dynamic`            # runs `samples/loadtest/stress-dynamic.toml`
+# - `just lt stress-dynamic sessions=10` # shorthand for `--sessions 10`
+# - `just lt stress-dynamic --sessions 10`
 # - `just lt dynamic-tune-heavy --cleanup`
 # - `just lt samples/loadtest/ui-demo.toml`
 lt preset_or_path='stress-oneshot' *args='':
@@ -118,7 +120,21 @@ lt preset_or_path='stress-oneshot' *args='':
       echo "   - If passing a path, ensure the file exists"; \
       exit 1; \
     fi; \
-    just skit-lt "$cfg" {{args}}
+    sessions=""; \
+    set -- {{args}}; \
+    if [ $# -ge 1 ]; then \
+      case "$1" in \
+        sessions=*) sessions="${1#sessions=}"; shift;; \
+        [0-9]*) sessions="$1"; shift;; \
+      esac; \
+    fi; \
+    if [ -n "$sessions" ]; then \
+      case "$sessions" in \
+        ''|*[!0-9]*) echo "❌ sessions must be an integer (got: '$sessions')"; exit 1;; \
+      esac; \
+      set -- --sessions "$sessions" "$@"; \
+    fi; \
+    just skit-lt "$cfg" "$@"
 
 # --- Load test presets ---
 # Run the standard oneshot stress test config

--- a/ui/src/components/NodeStateIndicator.tsx
+++ b/ui/src/components/NodeStateIndicator.tsx
@@ -413,15 +413,22 @@ export const NodeStateIndicator: React.FC<NodeStateIndicatorProps> = ({
   nodeId,
   sessionId,
 }) => {
-  // Get live stats for error badge display
+  const [isTooltipOpen, setIsTooltipOpen] = React.useState(false);
+
+  // IMPORTANT: avoid subscribing to node stats while the tooltip is closed.
+  // Stats are high-frequency and would otherwise cause constant re-renders of all node indicators.
   const liveStats = useSessionStore(
     React.useCallback(
-      (s) => (nodeId && sessionId ? s.sessions.get(sessionId)?.nodeStats[nodeId] : undefined),
-      [nodeId, sessionId]
+      (s) =>
+        isTooltipOpen && nodeId && sessionId
+          ? s.sessions.get(sessionId)?.nodeStats[nodeId]
+          : undefined,
+      [isTooltipOpen, nodeId, sessionId]
     )
   );
+
   const stats = liveStats ?? propStats;
-  const hasErrors = stats && stats.errored > 0;
+  const hasErrors = isTooltipOpen && stats && stats.errored > 0;
 
   const color = getStateColor(state);
   const label = getStateLabel(state);
@@ -439,7 +446,7 @@ export const NodeStateIndicator: React.FC<NodeStateIndicatorProps> = ({
     );
 
   return (
-    <SKTooltip content={content} side="top">
+    <SKTooltip content={content} side="top" onOpenChange={setIsTooltipOpen}>
       <div
         className="nodrag"
         style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'help' }}

--- a/ui/src/services/websocket.reconnection.test.ts
+++ b/ui/src/services/websocket.reconnection.test.ts
@@ -325,12 +325,12 @@ describe('WebSocketService reconnection', () => {
       expect(session?.isConnected).toBe(true);
     });
 
-    it('should unsubscribe from session and clear it', () => {
+    it('should unsubscribe from session and keep cached session', () => {
       service.subscribeToSession('session-1');
       service.unsubscribeFromSession('session-1');
 
       const session = useSessionStore.getState().getSession('session-1');
-      expect(session).toBeUndefined();
+      expect(session?.isConnected).toBe(false);
     });
 
     it('should update all subscribed sessions on connection status change', () => {

--- a/ui/src/services/websocket.ts
+++ b/ui/src/services/websocket.ts
@@ -201,6 +201,9 @@ export class WebSocketService {
   }
 
   private handleSessionDestroyed(payload: SessionDestroyedPayload): void {
+    this.subscribedSessions.delete(payload.session_id);
+    useSessionStore.getState().clearSession(payload.session_id);
+    useNodeParamsStore.getState().resetSession(payload.session_id);
     useTelemetryStore.getState().clearSession(payload.session_id);
   }
 
@@ -350,7 +353,9 @@ export class WebSocketService {
 
   unsubscribeFromSession(sessionId: string): void {
     this.subscribedSessions.delete(sessionId);
-    useSessionStore.getState().clearSession(sessionId);
+    // Keep the session entry so the Monitor session list can display the latest known status
+    // even when a session is not actively selected/subscribed.
+    useSessionStore.getState().setConnected(sessionId, false);
     useNodeParamsStore.getState().resetSession(sessionId);
   }
 


### PR DESCRIPTION
#### Summary

- skit-cli loadtest: add --sessions override; support in shell; update just lt args parsing and docs
- moq_subscriber: avoid reconnect storms on track cancel; add guard reconnect
- engine: add session.id to node_run spans; don’t drop subscribers on Full
- ui/monitor: show node issue reasons; keep cached session status on selection; reduce indicator re-render churn