### PR TITLE
fix(nodes): vp9 bindgen

### DIFF
--- a/.github/actions/setup-skit/action.yml
+++ b/.github/actions/setup-skit/action.yml
@@ -74,7 +74,9 @@ runs:
     - name: Install system dependencies
       if: inputs.runs-on-self-hosted != 'true'
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y libvpx-dev nasm
+      # libclang-dev is needed by bindgen (env-libvpx-sys "generate" feature);
+      # the free-disk-aggressive step removes the runner's preinstalled llvm.
+      run: sudo apt-get update && sudo apt-get install -y libvpx-dev nasm libclang-dev
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,7 +62,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libvpx-dev nasm cmake ninja-build yasm meson ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y libvpx-dev nasm libclang-dev cmake ninja-build yasm meson ffmpeg
 
       - name: Build and install SVT-AV1 from source (v4.1.0)
         run: |
@@ -288,7 +288,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install system dependencies (libvpx for VP9, nasm for AV1 assembly, meson for dav1d)
-        run: sudo apt-get update && sudo apt-get install -y libvpx-dev nasm cmake ninja-build yasm meson
+        run: sudo apt-get update && sudo apt-get install -y libvpx-dev nasm libclang-dev cmake ninja-build yasm meson
 
       - name: Build and install SVT-AV1 from source (v4.1.0)
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -182,9 +182,6 @@ jobs:
 
       - name: Build skit (with GPU + HW codecs + SVT-AV1 + dav1d)
         env:
-          VPX_LIB_DIR: /usr/lib/x86_64-linux-gnu
-          VPX_INCLUDE_DIR: /usr/include
-          VPX_VERSION: "1.13.0"
           CUDA_INCLUDE_PATH: /usr/include
           # bindgen (used by shiguredo_nvcodec) needs the clang builtin include
           # path so it can find stddef.h and other compiler-provided headers.

--- a/.github/workflows/pipeline-validation-nightly.yml
+++ b/.github/workflows/pipeline-validation-nightly.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libvpx-dev nasm cmake ninja-build yasm meson ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y libvpx-dev nasm libclang-dev cmake ninja-build yasm meson ffmpeg
 
       - name: Build and install SVT-AV1 from source (v4.1.0)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install system dependencies (libvpx for VP9, cmake + nasm for AV1 static build)
-        run: sudo apt-get update && sudo apt-get install -y libvpx-dev nasm cmake
+        run: sudo apt-get update && sudo apt-get install -y libvpx-dev nasm libclang-dev cmake
 
       - name: Build release binaries
         # -fuse-ld=bfd: override rust-lld with the system linker (ld.bfd).

--- a/.github/workflows/skit.yml
+++ b/.github/workflows/skit.yml
@@ -172,13 +172,6 @@ jobs:
 
       - name: Run GPU tests
         env:
-          # The self-hosted runner runs Ubuntu 24.04 which ships libvpx 1.14.0,
-          # but env-libvpx-sys 5.1.3 only has pre-generated FFI bindings up to
-          # 1.13.0.  Setting VPX_LIB_DIR bypasses pkg-config version detection
-          # and VPX_VERSION selects the 1.13.0 bindings (backward-compatible).
-          VPX_LIB_DIR: /usr/lib/x86_64-linux-gnu
-          VPX_INCLUDE_DIR: /usr/include
-          VPX_VERSION: "1.13.0"
           # Ubuntu's nvidia-cuda-toolkit installs headers to /usr/include, not
           # /usr/local/cuda/include.  Tell shiguredo_nvcodec where to find them.
           CUDA_INCLUDE_PATH: /usr/include

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,8 @@ Run `just --list` to see all available commands.
 
 ```bash
 sudo apt install libopus-dev cmake pkg-config libssl-dev
-# Optional for VP9/video builds and VP9 sample pipelines:
-sudo apt install libvpx-dev
+# Required for the default build (VP9 bindings are generated at build time):
+sudo apt install libvpx-dev libclang-dev
 ```
 
 ### Rust toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,29 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex 1.3.0",
+ "syn 2.0.118",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
@@ -1827,6 +1850,7 @@ version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ecdc636a02003406cc821aa9d703c888a966a3fd9bbdae9f7cf27d71720147"
 dependencies = [
+ "bindgen 0.68.1",
  "pkg-config",
 ]
 
@@ -3289,6 +3313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4453,6 +4483,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -8613,6 +8649,18 @@ dependencies = [
  "log",
  "raw-window-handle",
  "web-sys",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/crates/nodes/Cargo.toml
+++ b/crates/nodes/Cargo.toml
@@ -74,7 +74,9 @@ symphonia = { version = "0.6.0", optional = true, default-features = false, feat
 ] }
 webm = { version = "2.2.0", optional = true }
 shiguredo_mp4 = { version = "2026.3", optional = true }
-env-libvpx-sys = { version = "5.1.3", optional = true }
+# "generate" runs bindgen at build time: the crate's newest pregenerated
+# bindings stop at libvpx 1.13, but Ubuntu 24.04 ships 1.14.
+env-libvpx-sys = { version = "5.1.3", features = ["generate"], optional = true }
 image = { version = "0.25.10", optional = true, default-features = false, features = ["png", "jpeg"] }
 tiny-skia = { version = "0.12.0", optional = true }
 resvg = { version = "0.47", optional = true, default-features = false }


### PR DESCRIPTION
#### Summary

fixing vp9 builds on Ubuntu 24.04
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`8aad6d1`](https://github.com/streamer45/streamkit/pull/650/commits/8aad6d13fba4044eed577e4e161c66bb3fce37cc) |

<a href="https://staging.itsdev.in/review/streamer45/streamkit/pull/650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->